### PR TITLE
JBOSGI-81 JNDI integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <version.apache.ant>1.7.0</version.apache.ant>
         <version.apache.aries.blueprint>0.4</version.apache.aries.blueprint>
         <version.apache.aries.jmx>0.3</version.apache.aries.jmx>
+        <version.apache.aries.jndi>0.3.1</version.apache.aries.jndi>
         <version.apache.aries.proxy>0.4</version.apache.aries.proxy>
         <version.apache.aries.util>0.4</version.apache.aries.util>
         <version.apache.felix.configadmin>1.2.8</version.apache.felix.configadmin>
@@ -106,6 +107,11 @@
                 <groupId>org.apache.aries.jmx</groupId>
                 <artifactId>org.apache.aries.jmx</artifactId>
                 <version>${version.apache.aries.jmx}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.aries.jndi</groupId>
+                <artifactId>org.apache.aries.jndi</artifactId>
+                <version>${version.apache.aries.jndi}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.aries.proxy</groupId>

--- a/testsuite/example/pom.xml
+++ b/testsuite/example/pom.xml
@@ -45,6 +45,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.aries.jndi</groupId>
+            <artifactId>org.apache.aries.jndi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.aries.proxy</groupId>
             <artifactId>org.apache.aries.proxy</artifactId>
             <scope>provided</scope>

--- a/testsuite/example/src/test/java/org/jboss/test/osgi/example/NamingSupport.java
+++ b/testsuite/example/src/test/java/org/jboss/test/osgi/example/NamingSupport.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.test.osgi.example;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.jndi.JNDIContextManager;
+
+/**
+ * @author David Bosschaert
+ */
+public class NamingSupport extends RepositorySupport {
+    public static final String APACHE_ARIES_JNDI = "org.apache.aries.jndi:org.apache.aries.jndi";
+
+    public static void provideJNDIIntegration(BundleContext syscontext, Bundle bundle) throws BundleException {
+        AriesSupport.provideAriesUtil(syscontext, bundle);
+
+        // Version 0.3.1 of Aries JNDI depends on Aries Blueprint.
+        BlueprintSupport.provideBlueprint(syscontext, bundle);
+
+        ServiceReference ref = syscontext.getServiceReference(JNDIContextManager.class.getName());
+        if (ref == null) {
+            Bundle b = installSupportBundle(syscontext, getCoordinates(bundle, APACHE_ARIES_JNDI));
+            b.start();
+        }
+    }
+}

--- a/testsuite/example/src/test/java/org/jboss/test/osgi/example/jbossas/JNDIIntegrationTestCase.java
+++ b/testsuite/example/src/test/java/org/jboss/test/osgi/example/jbossas/JNDIIntegrationTestCase.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.test.osgi.example.jbossas;
+
+import java.io.InputStream;
+
+import javax.inject.Inject;
+import javax.naming.Context;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.osgi.resolver.v2.XRequirementBuilder;
+import org.jboss.osgi.testing.OSGiManifestBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.test.osgi.example.AriesSupport;
+import org.jboss.test.osgi.example.BlueprintSupport;
+import org.jboss.test.osgi.example.NamingSupport;
+import org.jboss.test.osgi.example.RepositorySupport;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.resource.Resource;
+import org.osgi.service.jndi.JNDIContextManager;
+import org.osgi.service.packageadmin.PackageAdmin;
+import org.osgi.service.repository.Repository;
+
+/**
+ * This test exercises the OSGi-JNDI integration and ensures it shares the naming system with JavaEE
+ *
+ * @author David Bosschaert
+ */
+@RunWith(Arquillian.class)
+public class JNDIIntegrationTestCase {
+
+    @Inject
+    public BundleContext context;
+
+    @Inject
+    public Bundle bundle;
+
+    @Deployment
+    public static JavaArchive createdeployment() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "example-jndi");
+        archive.addClasses(RepositorySupport.class, NamingSupport.class, AriesSupport.class, BlueprintSupport.class);
+        archive.addAsManifestResource(RepositorySupport.BUNDLE_VERSIONS_FILE);
+        archive.setManifest(new Asset() {
+            @Override
+            public InputStream openStream() {
+                OSGiManifestBuilder builder = OSGiManifestBuilder.newInstance();
+                builder.addBundleSymbolicName(archive.getName());
+                builder.addBundleManifestVersion(2);
+                builder.addImportPackages(PackageAdmin.class);
+                builder.addImportPackages(Context.class, JNDIContextManager.class);
+                builder.addImportPackages(XRequirementBuilder.class, Repository.class, Resource.class);
+                return builder.openStream();
+            }
+        });
+        return archive;
+    }
+
+    @Test
+    public void testOSGiNamingContext() throws Exception {
+        NamingSupport.provideJNDIIntegration(context, bundle);
+
+        JNDIContextManager mgr = getJNDIContextManager();
+        Context ictx = mgr.newInitialContext();
+
+        Object jbossContext = ictx.lookup("java:jboss");
+        Assert.assertNotNull("Should be able to find the java:jboss context", jbossContext);
+
+        Context svcCtx = (Context) ictx.lookup("osgi:servicelist/javax.naming.spi.ObjectFactory");
+        NamingEnumeration<NameClassPair> ne = svcCtx.list("");
+
+        int count = 0;
+        while (ne.hasMoreElements()) {
+            ne.next();
+            count++;
+        }
+        Assert.assertTrue("Should be at least one ObjectFactory found", count > 0);
+    }
+
+    private JNDIContextManager getJNDIContextManager() throws Exception {
+        int timeoutSeconds = 10;
+        while (timeoutSeconds > 0) {
+            ServiceReference ref = context.getServiceReference(JNDIContextManager.class.getName());
+            if (ref != null) {
+                Object svc = context.getService(ref);
+                if (svc instanceof JNDIContextManager) {
+                    return (JNDIContextManager) svc;
+                }
+            }
+
+            Thread.sleep(1000);
+            timeoutSeconds--;
+        }
+        throw new RuntimeException("Unable to obtain JNDI Context Manager Service");
+    }
+}

--- a/testsuite/example/src/test/java/org/jboss/test/osgi/example/jndi/JNDITestCase.java
+++ b/testsuite/example/src/test/java/org/jboss/test/osgi/example/jndi/JNDITestCase.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.test.osgi.example.jndi;
+
+import java.io.InputStream;
+
+import javax.inject.Inject;
+import javax.naming.Context;
+import javax.naming.spi.InitialContextFactory;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.osgi.resolver.v2.XRequirementBuilder;
+import org.jboss.osgi.testing.OSGiManifestBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.test.osgi.example.AriesSupport;
+import org.jboss.test.osgi.example.BlueprintSupport;
+import org.jboss.test.osgi.example.NamingSupport;
+import org.jboss.test.osgi.example.RepositorySupport;
+import org.jboss.test.osgi.example.jndi.bundle.MyInterface;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.resource.Resource;
+import org.osgi.service.jndi.JNDIContextManager;
+import org.osgi.service.packageadmin.ExportedPackage;
+import org.osgi.service.packageadmin.PackageAdmin;
+import org.osgi.service.repository.Repository;
+
+/**
+ * This test exercises the OSGi-JNDI integration
+ *
+ * @author David Bosschaert
+ */
+@RunWith(Arquillian.class)
+public class JNDITestCase {
+
+    @Inject
+    public BundleContext context;
+
+    @Inject
+    public Bundle bundle;
+
+    @Deployment
+    public static JavaArchive createdeployment() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "example-jndi");
+        archive.addClasses(RepositorySupport.class, NamingSupport.class, AriesSupport.class, BlueprintSupport.class);
+        archive.addClasses(MyInterface.class);
+        archive.addAsManifestResource(RepositorySupport.BUNDLE_VERSIONS_FILE);
+        archive.setManifest(new Asset() {
+            @Override
+            public InputStream openStream() {
+                OSGiManifestBuilder builder = OSGiManifestBuilder.newInstance();
+                builder.addBundleSymbolicName(archive.getName());
+                builder.addBundleManifestVersion(2);
+                builder.addImportPackages(PackageAdmin.class);
+                builder.addImportPackages(Context.class, InitialContextFactory.class, JNDIContextManager.class);
+                builder.addImportPackages(XRequirementBuilder.class, Repository.class, Resource.class);
+                builder.addExportPackages(MyInterface.class);
+                return builder.openStream();
+            }
+        });
+        return archive;
+    }
+
+    @Test
+    public void testOSGiNamingContext() throws Exception {
+        NamingSupport.provideJNDIIntegration(context, bundle);
+
+        JNDIContextManager mgr = getJNDIContextManager();
+
+        // Get the InitialContext and lookup the PackageAdmin OSGi service through JNDI
+        Context ictx = mgr.newInitialContext();
+        Object viaJNDI = ictx.lookup("osgi:service/" + PackageAdmin.class.getName());
+
+        // Make an invocation on PackageAdmin
+        PackageAdmin pa = (PackageAdmin) viaJNDI;
+        ExportedPackage ep = pa.getExportedPackage(MyInterface.class.getPackage().getName());
+        Assert.assertEquals(bundle, ep.getExportingBundle());
+    }
+
+    private JNDIContextManager getJNDIContextManager() throws Exception {
+        int timeoutSeconds = 10;
+        while (timeoutSeconds > 0) {
+            ServiceReference ref = context.getServiceReference(JNDIContextManager.class.getName());
+            if (ref != null) {
+                Object svc = context.getService(ref);
+                if (svc instanceof JNDIContextManager) {
+                    return (JNDIContextManager) svc;
+                }
+            }
+
+            Thread.sleep(1000);
+            timeoutSeconds--;
+        }
+        throw new RuntimeException("Unable to obtain JNDI Context Manager Service");
+    }
+}

--- a/testsuite/example/src/test/java/org/jboss/test/osgi/example/jndi/bundle/MyInterface.java
+++ b/testsuite/example/src/test/java/org/jboss/test/osgi/example/jndi/bundle/MyInterface.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.test.osgi.example.jndi.bundle;
+
+/**
+ * @author David Bosschaert
+ */
+public interface MyInterface {
+    String getValue();
+}

--- a/testsuite/example/src/test/resources/3rdparty-bundle.versions
+++ b/testsuite/example/src/test/resources/3rdparty-bundle.versions
@@ -1,5 +1,6 @@
 org.apache.aries.blueprint\:org.apache.aries.blueprint=@version.apache.aries.blueprint@
 org.apache.aries.jmx\:org.apache.aries.jmx=@version.apache.aries.jmx@
+org.apache.aries.jndi\:org.apache.aries.jndi=@version.apache.aries.jndi@
 org.apache.aries.proxy\:org.apache.aries.proxy=@version.apache.aries.proxy@
 org.apache.aries\:org.apache.aries.util=@version.apache.aries.util@
 org.apache.felix\:org.apache.felix.configadmin=@version.apache.felix.configadmin@


### PR DESCRIPTION
This commit adds two tests to the umbrella example test suite.
- JNDITestCase shows how the JNDI integration can be used on the OSGi level
- JNDIIntegrationTestCase shows that JavaEE names can also be looked up
  through the JNDI integration
